### PR TITLE
Feature proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,6 @@
   
 ![screenshot](https://i.imgur.com/oBeqt6V.png)
 
-# Looking for new maintainer
-
-**I know this repo has been needing some love. If anyone is interested in taking ownership of this repo, please contact me! Either [post a discussion](https://github.com/Mennaruuk/twayback/discussions/new) or email me at mennaruuk at protonmail dot com.**
 
 </div>
 
@@ -50,12 +47,20 @@ Twayback is a portmanteau of *Twitter* and the *Wayback Machine*. Enter your des
                                                           (can be combined with -to)
                                                           (format YYYY-MM-DD or YYYY/MM/DD
                                                           or YYYYMMDD, doesn't matter)
+                                                          
                                             
     -to, --todate                                         Narrow search for deleted Tweets *archived*
                                                           on and before this date
                                                           (can be combined with -from)
                                                           (format YYYY-MM-DD or YYYY/MM/DD
                                                           or YYYYMMDD, doesn't matter)
+
+
+    --proxy-file                                          Provide a list of proxies to use. You'll need this for checking large groups of tweets
+                                                          Each line should contain one `url:port` to use
+                                                          The script will pick a new proxy from the list at random after each --batch-size       
+
+
     Examples:
     twayback -u taylorswift13                             Downloads all of @taylorswift13's
                                                           deleted Tweets
@@ -75,26 +80,10 @@ Twayback is a portmanteau of *Twitter* and the *Wayback Machine*. Enter your des
                                                           between August 30, 2020 to
                                                           September 15, 2020
 
-## Installation
-### For Windows only
- 1. Download the latest EXE file.
- 2. Launch Command Prompt in the EXE file's directory.
- 3. Run the command `twayback -u USERNAME` (Replace `USERNAME` with your target handle).
-
-### For Windows, Linux, and macOS
- 1. Download the latest Python script ZIP file.
- 2. Extract ZIP file to a directory of your choice.
- 3. Open terminal in that directory.
- 4. Run the command `pip install -r requirements.txt`.
- 5. Run the command `twayback.py -u USERNAME` (Replace `USERNAME` with your target handle).
- 
- ### Additional information for macOS
- - You can also install Twayback in the following way:
+#### Installation
  ```
  git clone https://github.com/Mennaruuk/twayback
  ``` 
- 
- - You can also use Python Virtualenv (Virtual Environment) in order to avoid conflicting packages | libs
  
  ```
  cd twayback
@@ -103,7 +92,7 @@ Twayback is a portmanteau of *Twitter* and the *Wayback Machine*. Enter your des
  ```
  pip3 install -r requirements.txt
  ```
- depending on versions
+ or possibly
  ```
  pip install -r requirements.txt
  ```
@@ -126,7 +115,8 @@ Screenshots are done using Playwright. To successfully take screenshots, please 
  2. Run: `playwright install`.
 
 ## Troubleshooting
-The larger the number of tweets your query has the higher your chances of encountering errors during execution. The default speed settings for `--semaphore-size` and `--batch-size` are set to the fastest possible execution. Reduce these numbers to slow down your execution and reduce the chance of errors. 
+The default speed settings for `--semaphore-size` and `--batch-size` are set to the fastest possible execution. Reduce these numbers to slow down your execution and reduce the chance of errors. 
+For checking large numbers of tweets (> than 800) you'll need to use web proxies and `--proxy-file` flag
 
 ## Things to keep in mind
  - Quality of the HTML files depends on how the Wayback Machine saved them. Some are better than others.
@@ -134,10 +124,4 @@ The larger the number of tweets your query has the higher your chances of encoun
  - By definition, if an account is suspended or no longer exists, all their Tweets would be considered deleted.
  - Custom date range is not about when Tweets were made, but rather when they were _archived_. For example, a Tweet from 2011 may have been archived today.
 
-## Call for help 🙏
-I welcome, and encourage, contributions! They make my day.
-What I can think of off the top of my head:
- - **Increasing download speed:** It'd be nice to increase the speed at which files are downloaded. `requests` takes me 5 seconds to download a file in kilobytes. There exist faster alternatives to requests, such as `pycURL`, `faster_than_requests`, and `urllib3`. I haven't gotten them to successfully work. I just want to use the faster library to download the HTML files and parse the text, it's okay if the rest is done with `requests`.
- -  **Code simplification/improvement**: If you're a pro at Python and know better ways to do what's in the script, please feel free to do so! If it works well, if not better, I will most likely merge it 😃
- - **Error Handling:** Set up error handling that would react to crashes. Potentially saving work as it goes and trying to restart from a certain point after a crash. For example: In a session if it crashed after checking the status of half of the URLs it would then restart itself and know to skip the URLs it has already checked this session.
- - **Use of Proxiese:** Build in ability for users to set up list of proxy IPs to rotate through if traffic is being blocked or limited
+

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Twayback is a portmanteau of *Twitter* and the *Wayback Machine*. Enter your des
 
     --semaphore-size                                      Specify how many urls from --batch-size you would 
                                                           like to query asyncronously at once. Expecting an integer
-                                                          between 1 and 50. A larger number number will give you a speed
+                                                          between 1 and 50. A larger number will give you a speed
                                                           boost but at the risk of errors. Default = 50
     
     -from, --fromdate                                     Narrow search for deleted Tweets *archived*
@@ -60,6 +60,11 @@ Twayback is a portmanteau of *Twitter* and the *Wayback Machine*. Enter your des
                                                           Each line should contain one `url:port` to use
                                                           The script will pick a new proxy from the list at random after each --batch-size       
 
+    
+    Logs                                                  After checking a user's tweets but before you
+                                                          make a download selection, a folder will be created
+                                                          with that username. That folder will contain a log of:
+                                                          <deleted-twitter-url>:<deleted-wayback-url> in case you needed them
 
     Examples:
     twayback -u taylorswift13                             Downloads all of @taylorswift13's
@@ -79,6 +84,8 @@ Twayback is a portmanteau of *Twitter* and the *Wayback Machine*. Enter your des
                                                           deleted Tweets *archived*
                                                           between August 30, 2020 to
                                                           September 15, 2020
+
+    
 
 #### Installation
  ```

--- a/twayback.py
+++ b/twayback.py
@@ -17,17 +17,22 @@ from pathlib import Path
 from playwright.sync_api import sync_playwright
 from aiohttp import ClientSession, TCPConnector
 import asyncio
+import random
 
 # checks the status of a given url
-async def checkStatus(url, session: ClientSession, sem: asyncio.Semaphore):
+async def checkStatus(url, session: ClientSession, sem: asyncio.Semaphore, proxy_server):
     
     async with sem:
-        async with session.get(url) as response:
-            return url, response.status
+        if proxy_server == '':
+            async with session.get(url) as response:
+                return url, response.status
+        else:
+            async with session.get(url, proxy = proxy_server) as response:
+                return url, response.status
         
     
 # controls our async event loop
-async def asyncStarter(url_list, semaphore_size):
+async def asyncStarter(url_list, semaphore_size, proxy_server):
     # this will wrap our event loop and feed the the various urls to their async request function.
     status_list = []
     headers = {'user-agent':'Mozilla/5.0 (compatible; DuckDuckBot-Https/1.1; https://duckduckgo.com/duckduckbot)'}
@@ -39,7 +44,7 @@ async def asyncStarter(url_list, semaphore_size):
         # launch all the url checks concurrently as coroutines 
         # where is the session variable coming from??? is it the global one I defined above?
         # function is expecting an async session?
-        status_list = await asyncio.gather(*(checkStatus(u, a_session, sem) for u in url_list))
+        status_list = await asyncio.gather(*(checkStatus(u, a_session, sem, proxy_server) for u in url_list))
     # return a list of the results    
     return status_list
 
@@ -56,15 +61,25 @@ parser = argparse.ArgumentParser()
 parser.add_argument('-u', '--username', required=True, default='')
 parser.add_argument('-from', '--fromdate', required=False, default='')
 parser.add_argument('-to', '--todate', required=False, default='')
-parser.add_argument('--batch-size', type=int, required=False, default=100, help="How many urls to examine at once. Between 1 and 100")
+parser.add_argument('--batch-size', type=int, required=False, default=300, help="How many urls to examine at once. Between 1 and 100")
 parser.add_argument('--semaphore-size', type=int, required=False, default=50, help="How many urls(from --batch-size) to query at once. Between 1 and 50")
-
+parser.add_argument('--proxy-file', required=False, default='', help="A list of proxies the script will rotate through")
 args = vars(parser.parse_args())
+
 account_name = args['username']
 from_date = args['fromdate']
 to_date = args['todate']
 batch_size = args['batch_size']
 semaphore_size = args['semaphore_size']
+
+proxy_file = args['proxy_file']
+if proxy_file != '':
+    proxy_list = []
+    with open(proxy_file, "r") as f:
+        for x in f.readlines():
+            proxy_list.append(x.split("\n")[0])
+    proxy_server = "http://" + proxy_list[random.randint(0, len(proxy_list)-1)]
+
 remove_list = ['-', '/']
 from_date = from_date.translate({ord(x): None for x in remove_list})
 to_date = to_date.translate({ord(x): None for x in remove_list})
@@ -72,6 +87,7 @@ account_url = f"https://twitter.com/{account_name}"
 headers = {'User-Agent': 'Mozilla/5.0 (compatible; DuckDuckBot-Https/1.1; https://duckduckgo.com/duckduckbot)'}
 
 futures = []
+
 
 #####
 account_response = requests.get(account_url, headers=headers, allow_redirects=False)
@@ -121,9 +137,12 @@ results_list = []
 counter = 0
 for x in tqdm(range(0, len(twitter_url_list))):
     if counter==batch_size or x == len(twitter_url_list)-1 :
-        results_list.extend(asyncio.run(asyncStarter(twitter_url_list[x-batch_size:x], semaphore_size)))
+        results_list.extend(asyncio.run(asyncStarter(twitter_url_list[x-batch_size:x], semaphore_size, proxy_server)))
         counter = 0
-    counter += 1 
+        proxy_server = "http://" + proxy_list[random.randint(0, len(proxy_list)-1)] 
+        print(f"New Proxy: {proxy_server}")
+    counter += 1
+    
 
 # list of just missing twitter url
 missing_tweet_list = []

--- a/twayback.py
+++ b/twayback.py
@@ -102,6 +102,7 @@ elif status_code == 302:
           f"downloaded.")
 elif status_code ==429:
     print(Back.RED + Fore.WHITE + f"Respose Code 429: Too Many Requests. Your traffic to Twitter is being limited and results of this script will not be accurate")
+    exit()
 else:
     print(Back.RED + Fore.WHITE + f"No one currently has this handle. Twayback will search for a history of this "
           f"handle's Tweets.")
@@ -147,14 +148,16 @@ for x in tqdm(range(0, len(twitter_url_list))):
             proxy_server = ''
     counter += 1
     
-
+missed_tweet_count = 0
 # list of just missing twitter url
 missing_tweet_list = []
 for result in results_list:
     if result[1] == 404:
         missing_tweet_list.append(str(result[0]))
     if result[1] == 429:
-        print("Respose Code 429: Too Many Requests. Your traffic to Twitter is being limited and results of this script will not be accurate")
+        missed_tweet_count += 1
+if missed_tweet_count > 0:
+    print(f"Skipped {missed_tweet_count} tweets due to 429 error. Reccomend using rotating proxy servers")
 
 # list of wayback ids for just missing tweets
 wayback_id_list = []

--- a/twayback.py
+++ b/twayback.py
@@ -73,8 +73,9 @@ batch_size = args['batch_size']
 semaphore_size = args['semaphore_size']
 
 proxy_file = args['proxy_file']
+proxy_server = ''
+proxy_list = []
 if proxy_file != '':
-    proxy_list = []
     with open(proxy_file, "r") as f:
         for x in f.readlines():
             proxy_list.append(x.split("\n")[0])
@@ -139,8 +140,11 @@ for x in tqdm(range(0, len(twitter_url_list))):
     if counter==batch_size or x == len(twitter_url_list)-1 :
         results_list.extend(asyncio.run(asyncStarter(twitter_url_list[x-batch_size:x], semaphore_size, proxy_server)))
         counter = 0
-        proxy_server = "http://" + proxy_list[random.randint(0, len(proxy_list)-1)] 
-        print(f"New Proxy: {proxy_server}")
+        if proxy_list != []:
+            proxy_server = "http://" + proxy_list[random.randint(0, len(proxy_list)-1)] 
+            print(f"New Proxy: {proxy_server}")
+        else:
+            proxy_server = ''
     counter += 1
     
 


### PR DESCRIPTION
to avoid rate limiting for large groups of tweets
added the ability to use proxies with our GET  requests. 
User will need to provide a list of proxy URLs for the script to randomly pull from 